### PR TITLE
Fix for Meritocracy policy

### DIFF
--- a/Ceg/Ceg/Policies/Trees/CEP_Liberty.xml
+++ b/Ceg/Ceg/Policies/Trees/CEP_Liberty.xml
@@ -12,7 +12,8 @@
 			<Set GridX="1"
 				 GridY="1"
 				 NumCitiesPolicyCostDiscount="-33"
-				 GoldenAgeTurns="0"
+				 HappinessPerTradeRoute="0"
+				 UnhappinessMod="0"
 				 PortraitIndex="9"
 				 />
 		</Update>


### PR DESCRIPTION
Meritocracy unintentionally gave happiness for connected cities reduced
unhappiness from population in non-Occupied cities
