### PR TITLE
debug info added to cityview.lua

### DIFF
--- a/Cat/Cat/Interface/Bugfixes/CityView.lua
+++ b/Cat/Cat/Interface/Bugfixes/CityView.lua
@@ -9,6 +9,7 @@ include( "SupportFunctions"  );
 include( "TutorialPopupScreen" );
 include( "InfoTooltipInclude" );
 
+print("CEP CityView.lua")
 
 local g_BuildingIM   = InstanceManager:new( "BuildingInstance", "BuildingButton", Controls.BuildingStack );
 local g_GPIM   = InstanceManager:new( "GPInstance", "GPBox", Controls.GPStack );


### PR DESCRIPTION
Small print statement added to make it easier to track down
incompatibility problems with other mods using the file, e.g. CSD
