### PR TITLE
Arabian Text Trait Bug Fix

### DIFF
--- a/Ceg/Ceg/Leaders/CEL__A_I.xml
+++ b/Ceg/Ceg/Leaders/CEL__A_I.xml
@@ -105,6 +105,8 @@
 			<Where Type="TRAIT_LAND_TRADE_GOLD" />
 			<Set LandTradeRouteRangeBonus="10"
 				 TradeReligionModifier="100"
+				 ShortDescription="TXT_KEY_TRAIT_LAND_TRADE_GOLD_SHORT"
+				 Description="TXT_KEY_TRAIT_LAND_TRADE_GOLD"
 				 />
 		</Update>
 	</Traits>


### PR DESCRIPTION
The Text for the Arabian trait is called
"TXT_KEY_TRAIT_LAND_TRADE_GOLD2" while CEP uses the same thing without
the '2'
This minor fix points the variables of Description and ShortDescription
to the CEP text instead of the vanilla text.
